### PR TITLE
ci: fix semantic pr check workflow path

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -11,4 +11,4 @@ permissions:
 jobs:
   semantic_pr-name:
     name: semantic_pr-name
-    uses: evva-sfw/workflows/.github/workflows/semantic.yml@main
+    uses: evva-sfw/workflows/.github/workflows/call_semantic.yml@main


### PR DESCRIPTION
Bypass rules to get the semantic pr check working again.
iOS build errors are addressed in #27 