### PR TITLE
ci: fix missing workflow permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: build
+permissions:
+  contents: read
 on:
   push:
     branches: [ 'main' ]

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,4 +1,6 @@
 name: cache
+permissions:
+  contents: read
 on:
   pull_request:
     types:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install Node.js
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,4 +1,6 @@
 name: npm
+permissions:
+  contents: read
 on:
   push:
     branches: [ 'main' ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: test
+permissions:
+  contents: read
 on:
   push:
     branches: [ 'main' ]


### PR DESCRIPTION
Potential fix for [https://github.com/evva-sfw/abrevva-capacitor/security/code-scanning/8](https://github.com/evva-sfw/abrevva-capacitor/security/code-scanning/8)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific permissions. Based on the workflow's steps, it appears that only read access to the repository contents is required. Therefore, we will set `contents: read` as the minimal permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
