### PR TITLE
ci: add type sec to changelog in release-it

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,87 +1,91 @@
 {
-    "$schema": "https://unpkg.com/release-it@17/schema/release-it.json",
-    "hooks": {
-        "after:bump": [
-            "rm -f *.tgz",
-            "yarn pack --out '%s_%v.tgz'",
-            "npx auto-changelog -c .auto-changelog"
+  "$schema": "https://unpkg.com/release-it@19/schema/release-it.json",
+  "hooks": {
+    "after:bump": [
+      "rm -f *.tgz",
+      "yarn pack --out '%s_%v.tgz'",
+      "npx auto-changelog -c .auto-changelog"
+    ]
+  },
+  "git": {
+    "commitMessage": "chore: release ${version}",
+    "tagName": "${version}",
+    "commitArgs": [
+      "-S"
+    ],
+    "tagArgs": [
+      "-s"
+    ]
+  },
+  "npm": {
+    "publish": true,
+    "publishArgs": [
+      "--provenance"
+    ]
+  },
+  "github": {
+    "release": true,
+    "assets": [
+      "*.tgz"
+    ],
+    "tokenRef": "BOT_GITHUB_TOKEN"
+  },
+  "plugins": {
+    "@release-it/conventional-changelog": {
+      "preset": {
+        "name": "conventionalcommits",
+        "types": [
+          {
+            "type": "feat",
+            "section": "🎉 Features"
+          },
+          {
+            "type": "fix",
+            "section": "🐛 Bug Fixes"
+          },
+          {
+            "type": "perf",
+            "section": "⚡️ Performance Improvements"
+          },
+          {
+            "type": "revert",
+            "section": "⏪️ Reverts"
+          },
+          {
+            "type": "docs",
+            "section": "📝 Documentation"
+          },
+          {
+            "type": "style",
+            "section": "🎨 Styles"
+          },
+          {
+            "type": "refactor",
+            "section": "🔀 Code Refactoring"
+          },
+          {
+            "type": "test",
+            "section": "🧪 Tests"
+          },
+          {
+            "type": "build",
+            "section": "⚙️ Build System"
+          },
+          {
+            "type": "ci",
+            "section": "🚀 Continuous Integration"
+          },
+          {
+            "type": "sec",
+            "section": "🛡️ Security Fix"
+          },
+          {
+            "type": "chore",
+            "section": "🧹 Chore"
+          }
         ]
-    },
-    "git": {
-        "commitMessage": "chore: release ${version}",
-        "tagName": "${version}",
-        "commitArgs": [
-            "-S"
-        ],
-        "tagArgs": [
-            "-s"
-        ]
-    },
-    "npm": {
-        "publish": true,
-        "publishArgs": [
-            "--provenance"
-        ]
-    },
-    "github": {
-        "release": true,
-        "assets": [
-            "*.tgz"
-        ],
-        "tokenRef": "BOT_GITHUB_TOKEN"
-    },
-    "plugins": {
-        "@release-it/conventional-changelog": {
-            "preset": {
-                "name": "conventionalcommits",
-                "types": [
-                    {
-                        "type": "feat",
-                        "section": "🎉 Features"
-                    },
-                    {
-                        "type": "fix",
-                        "section": "🐛 Bug Fixes"
-                    },
-                    {
-                        "type": "perf",
-                        "section": "⚡️ Performance Improvements"
-                    },
-                    {
-                        "type": "revert",
-                        "section": "⏪️ Reverts"
-                    },
-                    {
-                        "type": "docs",
-                        "section": "📝 Documentation"
-                    },
-                    {
-                        "type": "style",
-                        "section": "🎨 Styles"
-                    },
-                    {
-                        "type": "refactor",
-                        "section": "🔀 Code Refactoring"
-                    },
-                    {
-                        "type": "test",
-                        "section": "🧪 Tests"
-                    },
-                    {
-                        "type": "build",
-                        "section": "⚙️ Build System"
-                    },
-                    {
-                        "type": "ci",
-                        "section": "🚀 Continuous Integration"
-                    },
-                    {
-                        "type": "chore",
-                        "section": "🧹 Chore"
-                    }
-                ]
-            },
-            "infile": "CHANGELOG.md"
-        }
+      },
+      "infile": "CHANGELOG.md"
     }
+  }
 }


### PR DESCRIPTION
Change introduced from here: https://github.com/evva-sfw/workflows/pull/8

> [!IMPORTANT]
> Please make a **patch** release after merge.