### PR TITLE
docs: set license name

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "LICENSE"
   ],
   "author": "EVVA Sicherheitstechnologie GmbH",
-  "license": "SEE LICENSE IN <LICENSE>",
+  "license": "EVVA Software License",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/evva-sfw/abrevva-capacitor.git"


### PR DESCRIPTION
Set package.json license name to: EVVA Software License
Reason: we need a unique identifier to allow our license in license scans